### PR TITLE
Added Item groups as outlined in feature #24

### DIFF
--- a/src/main/java/com/nationsandkings/NationsAndKings.java
+++ b/src/main/java/com/nationsandkings/NationsAndKings.java
@@ -2,6 +2,7 @@ package com.nationsandkings;
 
 import com.nationsandkings.blocks.ModBlocks;
 import com.nationsandkings.entity.Entities;
+import com.nationsandkings.items.ModItems;
 import net.fabricmc.api.ModInitializer;
 
 import org.slf4j.Logger;
@@ -23,6 +24,9 @@ public class NationsAndKings implements ModInitializer {
 		// Proceed with mild caution.
 
 		LOGGER.info("Hello Fabric world!");
+
+		LOGGER.info("Registering Mod Items & Item Groups");
+		ModItems.initialize();
 
 		LOGGER.info("Registering Mod Entities");
 		Entities.RegisterModEntities();

--- a/src/main/java/com/nationsandkings/blocks/ModBlocks.java
+++ b/src/main/java/com/nationsandkings/blocks/ModBlocks.java
@@ -1,6 +1,7 @@
 package com.nationsandkings.blocks;
 
 import com.nationsandkings.NationsAndKings;
+import com.nationsandkings.items.ModItems;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
@@ -108,7 +109,7 @@ public class ModBlocks {
 //        });
 
 
-        ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register((itemGroup) -> {
+        ItemGroupEvents.modifyEntriesEvent(ModItems.WORKSTATIONS_GROUP_KEY).register((itemGroup) -> {
             itemGroup.add(ModBlocks.TOWN_HALL.asItem());
         });
     }

--- a/src/main/java/com/nationsandkings/items/ModItems.java
+++ b/src/main/java/com/nationsandkings/items/ModItems.java
@@ -1,0 +1,4 @@
+package com.nationsandkings.items;
+
+public class ModItems {
+}

--- a/src/main/java/com/nationsandkings/items/ModItems.java
+++ b/src/main/java/com/nationsandkings/items/ModItems.java
@@ -1,12 +1,19 @@
 package com.nationsandkings.items;
 
 import com.nationsandkings.NationsAndKings;
+import com.nationsandkings.blocks.ModBlocks;
+import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.item.Item;
+import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.Identifier;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
 
 
 public class ModItems {
@@ -24,12 +31,49 @@ public class ModItems {
     // Start registering items here
 
     public static final RegistryKey<Item> COPPER_COIN_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(NationsAndKings.MOD_ID, "copper_coin"));
-    public static final Item SUSPICIOUS_SUBSTANCE = register(
+    public static final Item COPPER_COINS = register(
             new Item(new Item.Settings().registryKey(COPPER_COIN_KEY)),
             COPPER_COIN_KEY
     );
 
+
+
+    public static final RegistryKey<ItemGroup> WORKSTATIONS_GROUP_KEY = RegistryKey.of(Registries.ITEM_GROUP.getKey(), Identifier.of(NationsAndKings.MOD_ID, "nak_workstations"));
+    public static final ItemGroup WORKSTATIONS_GROUP = FabricItemGroup.builder()
+            .icon(() -> new ItemStack(ModBlocks.TOWN_HALL.asItem()))
+            .displayName(Text.translatable("nak_workstations.nationsandkings"))
+            .build();
+
+    public static final RegistryKey<ItemGroup> DECORATIVE_ITEMS_BLOCKS_KEY = RegistryKey.of(Registries.ITEM_GROUP.getKey(), Identifier.of(NationsAndKings.MOD_ID, "nak_decorations"));
+    public static final ItemGroup DECORATIVE_ITEMS_BLOCKS = FabricItemGroup.builder()
+            .icon(() -> new ItemStack(Items.OAK_LEAVES))
+            .displayName(Text.translatable("nak_decorations.nationsandkings"))
+            .build();
+
+    public static final RegistryKey<ItemGroup> COINS_GROUP_KEY = RegistryKey.of(Registries.ITEM_GROUP.getKey(), Identifier.of(NationsAndKings.MOD_ID, "nak_coins"));
+    public static final ItemGroup COINS_GROUP = FabricItemGroup.builder()
+            .icon(() -> new ItemStack(Items.EMERALD))
+            .displayName(Text.translatable("nak_coins"))
+            .build();
+
+
     public static void initialize() {
+        Registry.register(Registries.ITEM_GROUP, WORKSTATIONS_GROUP_KEY, WORKSTATIONS_GROUP);
+        Registry.register(Registries.ITEM_GROUP, DECORATIVE_ITEMS_BLOCKS_KEY, DECORATIVE_ITEMS_BLOCKS);
+        Registry.register(Registries.ITEM_GROUP, COINS_GROUP_KEY, COINS_GROUP);
+
+        //Adding Items to the COINS_GROUP
+        ItemGroupEvents.modifyEntriesEvent(COINS_GROUP_KEY).register(itemGroup -> {
+            itemGroup.add(ModItems.COPPER_COINS);
+        });
+
+        //Adding Items to the decorative group
+        ItemGroupEvents.modifyEntriesEvent(DECORATIVE_ITEMS_BLOCKS_KEY).register(itemGroup -> {
+            itemGroup.add(Items.VINE);
+        });
+
+
+
 
     }
 }

--- a/src/main/java/com/nationsandkings/items/ModItems.java
+++ b/src/main/java/com/nationsandkings/items/ModItems.java
@@ -1,8 +1,21 @@
 package com.nationsandkings.items;
 
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+
 public class ModItems {
 
+    //From the fabric wiki, we can change later
+    public static Item register(Item item, RegistryKey<Item> registryKey) {
+        // Register the item.
+        Item registeredItem = Registry.register(Registries.ITEM, registryKey.getValue(), item);
 
+        // Return the registered item!
+        return registeredItem;
+
+    }
     public static void initialize() {
 
     }

--- a/src/main/java/com/nationsandkings/items/ModItems.java
+++ b/src/main/java/com/nationsandkings/items/ModItems.java
@@ -1,9 +1,13 @@
 package com.nationsandkings.items;
 
+import com.nationsandkings.NationsAndKings;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+
 
 public class ModItems {
 
@@ -16,6 +20,15 @@ public class ModItems {
         return registeredItem;
 
     }
+
+    // Start registering items here
+
+    public static final RegistryKey<Item> COPPER_COIN_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(NationsAndKings.MOD_ID, "copper_coin"));
+    public static final Item SUSPICIOUS_SUBSTANCE = register(
+            new Item(new Item.Settings().registryKey(COPPER_COIN_KEY)),
+            COPPER_COIN_KEY
+    );
+
     public static void initialize() {
 
     }

--- a/src/main/java/com/nationsandkings/items/ModItems.java
+++ b/src/main/java/com/nationsandkings/items/ModItems.java
@@ -62,15 +62,17 @@ public class ModItems {
         Registry.register(Registries.ITEM_GROUP, DECORATIVE_ITEMS_BLOCKS_KEY, DECORATIVE_ITEMS_BLOCKS);
         Registry.register(Registries.ITEM_GROUP, COINS_GROUP_KEY, COINS_GROUP);
 
+        //Adding Items to the decorative group
+        ItemGroupEvents.modifyEntriesEvent(DECORATIVE_ITEMS_BLOCKS_KEY).register(itemGroup -> {
+            itemGroup.add(Items.VINE);
+        });
+
         //Adding Items to the COINS_GROUP
         ItemGroupEvents.modifyEntriesEvent(COINS_GROUP_KEY).register(itemGroup -> {
             itemGroup.add(ModItems.COPPER_COINS);
         });
 
-        //Adding Items to the decorative group
-        ItemGroupEvents.modifyEntriesEvent(DECORATIVE_ITEMS_BLOCKS_KEY).register(itemGroup -> {
-            itemGroup.add(Items.VINE);
-        });
+
 
 
 

--- a/src/main/java/com/nationsandkings/items/ModItems.java
+++ b/src/main/java/com/nationsandkings/items/ModItems.java
@@ -1,4 +1,9 @@
 package com.nationsandkings.items;
 
 public class ModItems {
+
+
+    public static void initialize() {
+
+    }
 }

--- a/src/main/resources/assets/nationsandkings/lang/en_us.json
+++ b/src/main/resources/assets/nationsandkings/lang/en_us.json
@@ -1,3 +1,6 @@
 {
-  "item.nationsandkings.town_hall": "Town Hall"
+  "item.nationsandkings.town_hall": "Town Hall",
+  "nak_workstations.nationsandkings": "Villager Workstations",
+  "nak_decorations.nationsandkings": "Village Decorations",
+  "nak_coins": "Villager Currency"
 }


### PR DESCRIPTION
<!Pull Request Template>

## Description

The item groups, with some example items, have been added to the creative menu.


## Tests

Manually verification of the itemGroups existence in the creative menus

## UI Changes

3 Item groups, Workstations, Currency and Decorations have been added to the creative menu.
![image](https://github.com/user-attachments/assets/f918ef32-716c-48a9-8344-96c4c823237a)


## Issues

Closes #24 

## Additional Notes

Items and Blocks will need to be added manually as they are created.

---
